### PR TITLE
Added Norderstedt to supported cities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Supported services:
 * Gütersloh
 * Halver
 * Coesfeld
+* Norderstedt
 
 ![alt text](https://github.com/tuxuser/abfallapi_regioit_ha/blob/master/preview1.png "glance card")
 

--- a/custom_components/abfallapi_regioit/regioit_abfall_api.py
+++ b/custom_components/abfallapi_regioit/regioit_abfall_api.py
@@ -44,6 +44,8 @@ BASE_URL_GT2 = 'https://gt2-abfallapp.regioit.de/abfall-app-gt2'
 BASE_URL_HLV = 'https://hlv-abfallapp.regioit.de/abfall-app-hlv'
 # Coesfeld
 BASE_URL_COE = 'https://coe-abfallapp.regioit.de/abfall-app-coe'
+# Norderstedt
+BASE_URL_NDS = 'https://nds-abfallapp.regioit.de/abfall-app-nds'
 
 CITIES = {
     'Bergisch Gladbach': BASE_URL_BGL,
@@ -59,7 +61,8 @@ CITIES = {
     'Dorsten': BASE_URL_DORSTEN,
     'Guetersloh': BASE_URL_GT2,
     'Halver': BASE_URL_HLV,
-    'Coesfeld': BASE_URL_COE
+    'Coesfeld': BASE_URL_COE,
+    'Norderstedt': BASE_URL_NDS
 }
 
 class RegioItAbfallApi(object):


### PR DESCRIPTION
I started reverse engineering an ios app for our local garbage collector. Found out that it is backed by regioit and reminded myself that there was a regioit integration in HACS. 👍 

Therefore, thanks for implementing a sensor for it! I just added Norderstedt to the supported cities with the specific url. 